### PR TITLE
[STAFF] Fix `ReachabilitySwift.podspec` resource bundle for privacy (No-Ticket)

### DIFF
--- a/ReachabilitySwift.podspec
+++ b/ReachabilitySwift.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
     :tag => 'v'+s.version.to_s
   }
   s.source_files = 'Sources/Reachability.swift'
-  s.resource_bundles = {"Kingfisher" => ["Sources/PrivacyInfo.xcprivacy"]}
+  s.resource_bundles = {"ReachabilitySwift_Privacy" => ["Sources/PrivacyInfo.xcprivacy"]}
   s.framework    = 'SystemConfiguration'
   s.ios.framework    = 'CoreTelephony'
 


### PR DESCRIPTION
Fix privacy resource bundle that is currently `Kingfisher` into `ReachabilitySwift_Privacy ` aligned with the other libraries.